### PR TITLE
🦥 No urgent flag

### DIFF
--- a/alacritty/src/event.rs
+++ b/alacritty/src/event.rs
@@ -1307,12 +1307,6 @@ impl input::Processor<EventProxy, ActionContext<'_, Notifier, EventProxy>> {
                         }
                     },
                     TerminalEvent::Bell => {
-                        // Set window urgency hint when window is not focused.
-                        let focused = self.ctx.terminal.is_focused;
-                        if !focused && self.ctx.terminal.mode().contains(TermMode::URGENCY_HINTS) {
-                            self.ctx.window().set_urgent(true);
-                        }
-
                         // Ring visual bell.
                         self.ctx.display.visual_bell.ring();
 


### PR DESCRIPTION
Disables the urgent flag triggering on a bell.

Not to be merged, just track its existence.